### PR TITLE
Use numeric sorting of choices when applicable

### DIFF
--- a/rivalcfg/helpers.py
+++ b/rivalcfg/helpers.py
@@ -117,7 +117,7 @@ def choices_to_list(choices):
     Arguments:
     choices -- the dict containing available choices
     """
-    return sorted([str(choice) for choice in choices.keys()])
+    return map(str, sorted(choices.keys()))
 
 
 def choices_to_string(choices):


### PR DESCRIPTION
This improves the listing of the sensitivity choices.

Before:
```
    -p POLLING_RATE, --polling-rate=POLLING_RATE
                        Set polling rate in Hz (values: 1000, 125, 250, 500,
                        default: 1000)
    -s SENSITIVITY1, --sensitivity1=SENSITIVITY1
                        Set sensitivity preset 1 (values: 1000, 1250, 1500,
                        1750, 2000, 250, 4000, 500, default: 1000)
    -S SENSITIVITY2, --sensitivity2=SENSITIVITY2
                        Set sensitivity preset 2 (values: 1000, 1250, 1500,
                        1750, 2000, 250, 4000, 500, default: 2000)
```

After:
```
    -p POLLING_RATE, --polling-rate=POLLING_RATE
                        Set polling rate in Hz (values: 125, 250, 500, 1000,
                        default: 1000)
    -s SENSITIVITY1, --sensitivity1=SENSITIVITY1
                        Set sensitivity preset 1 (values: 250, 500, 1000,
                        1250, 1500, 1750, 2000, 4000, default: 1000)
    -S SENSITIVITY2, --sensitivity2=SENSITIVITY2
                        Set sensitivity preset 2 (values: 250, 500, 1000,
                        1250, 1500, 1750, 2000, 4000, default: 2000)
```