### PR TITLE
Add initial support for the rival 310

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,9 @@ Supported mice:
 * SteelSeries Rival 300 CS:GO Fade Edition _(1038:1394)_
 * SteelSeries Rival 300 CS:GO Hyperbeast Edition _(1038:171a)_
 
+Experimental support:
+* SteelSeries Rival 310 _(1038:1720)_
+
 If you have trouble running this software, please open an issue on Github:
 
 * https://github.com/flozz/rivalcfg/issues
@@ -142,6 +145,15 @@ SteelSeries Rival 300 CS:GO Fade Edition Options:
                         breathmed, breathslow, steady, 1, 2, 3, 4, default:
                         steady)
     -r, --reset         Reset all options to their factory values
+
+SteelSeries Rival 310 Options:
+
+    -s SENSITIVITY1, --sensitivity1=SENSITIVITY1
+                        Set sensitivity preset 1 (from 100 to 12000 in
+                        increments of 100, default: 800)
+    -S SENSITIVITY2, --sensitivity2=SENSITIVITY2
+                        Set sensitivity preset 2 (from 100 to 12000 in
+                        increments of 100, default: 1600)
 
 
 ## FAQ (Frequently Asked Questions)

--- a/rivalcfg/data/99-steelseries-rival.rules
+++ b/rivalcfg/data/99-steelseries-rival.rules
@@ -7,5 +7,8 @@ SUBSYSTEM=="hidraw", ATTRS{idVendor}=="1038", ATTRS{idProduct}=="1702", MODE="06
 # SteelSeries Rival 300
 SUBSYSTEM=="hidraw", ATTRS{idVendor}=="1038", ATTRS{idProduct}=="1710", MODE="0666"
 
+# SteelSeries Rival 310 eSports Mouse
+SUBSYSTEM=="hidraw", ATTRS{idVendor}=="1038", ATTRS{idProduct}=="1720", MODE="0666"
+
 # SteelSeries Rival 300 CS:GO Fade Edition
 SUBSYSTEM=="hidraw", ATTRS{idVendor}=="1038", ATTRS{idProduct}=="1394", MODE="0666"

--- a/rivalcfg/mice/__init__.py
+++ b/rivalcfg/mice/__init__.py
@@ -1,6 +1,7 @@
 from .rival import rival
 from .rival100 import rival100
 from .rival300 import rival300
+from .rival310 import rival310
 from .rival300csgofadeedition import rival300csgofadeedition
 from .rival300csgohyperbeastedition import rival300csgohyperbeastedition
 
@@ -10,4 +11,5 @@ mice_list = [
     rival300,
     rival300csgofadeedition,
     rival300csgohyperbeastedition,
+    rival310,
 ]

--- a/rivalcfg/mice/rival310.py
+++ b/rivalcfg/mice/rival310.py
@@ -1,0 +1,48 @@
+rival310 = {
+    "name": "SteelSeries Rival 310",
+
+    "vendor_id": "1038",
+    "product_id": "1720",
+    "hidraw_interface_number": 0,
+
+    "command_before": None,
+    "command_after": "save",
+
+    "commands": {
+
+        # TODO
+        "set_sensitivity1": {
+            "description": "Set sensitivity preset 1",
+            "cli": ["-s", "--sensitivity1"],
+            "command": [0x53, 0x00, 0x01],
+            "value_type": "range",
+            "range_min": 100,
+            "range_max": 12000,
+            "range_increment": 100,
+            "value_transform": lambda x: int(x / 100),
+            "default": 800,
+        },
+
+        # TODO
+        "set_sensitivity2": {
+            "description": "Set sensitivity preset 2",
+            "cli": ["-S", "--sensitivity2"],
+            "command": [0x53, 0x00, 0x02],
+            "value_type": "range",
+            "range_min": 100,
+            "range_max": 12000,
+            "range_increment": 100,
+            "value_transform": lambda x: int(x / 100),
+            "default": 1600,
+        },
+
+        "save": {
+            "description": "Save the configuration to the mouse memory",
+            "cli": None,
+            "command": [0x59, 0x00],
+            "value_type": None,
+        },
+
+    },
+
+}


### PR DESCRIPTION
This just adds support for the 2 sensitivity settings of the rival 310.
We still need to support the light modes, poll rate, and other things,
but at least this is an easy start.


I left the todo in since I don't know if the values are entirely correct. I've tested it on my own mouse, and it seems functional.

If anyone wants pcap files for developing further fell free to ask.