### PR TITLE
Added support for Rival 300 HP Omen Edition

### DIFF
--- a/rivalcfg/data/99-steelseries-rival.rules
+++ b/rivalcfg/data/99-steelseries-rival.rules
@@ -22,6 +22,10 @@ SUBSYSTEM=="usb", ATTRS{idVendor}=="1038", ATTRS{idProduct}=="1394", MODE="0666"
 SUBSYSTEM=="hidraw", ATTRS{idVendor}=="1038", ATTRS{idProduct}=="171A", MODE="0666"
 SUBSYSTEM=="usb", ATTRS{idVendor}=="1038", ATTRS{idProduct}=="171A", MODE="0666"
 
+# SteelSeries Rival 300 HP Omen Edition
+SUBSYSTEM=="hidraw", ATTRS{idVendor}=="1038", ATTRS{idProduct}=="1718", MODE="0666"
+SUBSYSTEM=="usb", ATTRS{idVendor}=="1038", ATTRS{idProduct}=="1718", MODE="0666"
+
 # SteelSeries Rival 310 eSports Mouse
 SUBSYSTEM=="hidraw", ATTRS{idVendor}=="1038", ATTRS{idProduct}=="1720", MODE="0666"
 SUBSYSTEM=="usb", ATTRS{idVendor}=="1038", ATTRS{idProduct}=="1720", MODE="0666"

--- a/rivalcfg/profiles/__init__.py
+++ b/rivalcfg/profiles/__init__.py
@@ -5,6 +5,7 @@ from .rival300 import rival300
 from .rival310 import rival310
 from .rival300csgofadeedition import rival300csgofadeedition
 from .rival300csgohyperbeastedition import rival300csgohyperbeastedition
+from .rival300hpomen import rival300hpomen
 from .rival500 import rival500
 from .hotssenseiraw import hotssenseiraw
 
@@ -15,6 +16,7 @@ mice_profiles = [
     rival300,
     rival300csgofadeedition,
     rival300csgohyperbeastedition,
+    rival300hpomen,
     rival310,
     rival500,
     hotssenseiraw,

--- a/rivalcfg/profiles/rival300hpomen.py
+++ b/rivalcfg/profiles/rival300hpomen.py
@@ -1,0 +1,11 @@
+from .rival import rival
+
+rival300hpomen = {
+    "name": "SteelSeries Rival 300 HP Omen Edition",
+
+    "vendor_id": 0x1038,
+    "product_id": 0x1718,
+    "interface_number": 0,
+
+    "commands": rival["commands"]
+}


### PR DESCRIPTION
Support added for this mouse: https://store.hp.com/us/en/pdp/hp-omen-mouse-with-steelseries

Mouse identical to SteelSeries Rival 300.

Closes #51 