### PR TITLE
Added support for gradients for orignal Rival and similar mice

### DIFF
--- a/rivalcfg/cli.py
+++ b/rivalcfg/cli.py
@@ -62,6 +62,22 @@ def _add_rgbcolor_option(group, command_name, command):
             )
 
 
+def _add_hsvgradient_option(group, command_name, command):
+    description = "%s (e.g. 0.1 1.0 255, default: %s)" % (
+            command["description"],
+            str(command["default"])
+            )
+    group.add_option(
+            *command["cli"],
+            dest=command_name,
+            help=description,
+            type="string",
+            action="callback",
+            callback=_check_color,
+            metavar=_command_name_to_metavar(command_name)
+            )
+
+
 def _add_rgbcolorshift_option(group, command_name, command):
     description = "%s (e.g. red aqua 200, ff0000 00ffff 200, default: %s %s)" % (  # noqa
             command["description"],

--- a/rivalcfg/command_handlers.py
+++ b/rivalcfg/command_handlers.py
@@ -1,4 +1,5 @@
 from . import helpers
+import colorsys
 
 
 def _transform(command, *args):
@@ -48,6 +49,15 @@ def rgbcolor_handler(command, *args):
         color = helpers.color_string_to_rgb(args[0])
     else:
         raise ValueError("Not a valid color %s" % str(args))
+    color = _transform(command, *color)
+    return helpers.merge_bytes(command["command"], color)
+
+
+def hsvgradient_handler(command, h=0.1, s=1.0, v=255, max_h=1.0, t=0.0):
+    """TODO write this.
+    """
+    color = [int(i) for i in colorsys.hsv_to_rgb(float(h)+(float(max_h)-float(h))*t,
+                                                 float(s), float(v))]
     color = _transform(command, *color)
     return helpers.merge_bytes(command["command"], color)
 

--- a/rivalcfg/helpers.py
+++ b/rivalcfg/helpers.py
@@ -61,7 +61,7 @@ def is_color(string):
     """
     if string in NAMED_COLORS:
         return True
-    if re.match(r"^#?[0-9a-f]{3}([0-9a-f]{3})?$", string, re.IGNORECASE):
+    if re.match(r"^#?[0-9a-f.]{3}([0-9a-f.]{3})?$", string, re.IGNORECASE):
         return True
     return False
 

--- a/rivalcfg/mouse.py
+++ b/rivalcfg/mouse.py
@@ -1,5 +1,4 @@
 import time
-import colorsys
 from . import usbhid
 from . import debug
 from . import helpers
@@ -83,19 +82,19 @@ class Mouse:
 
         def _exec_command(*args):
             if is_gradient:
-                h = 0.01
-                s = 1.0
-                v = 255
+                t = 0.01
                 c = 1
+                SLEEP = 0.02
+                INCREMENT = 0.001
                 while True:
-                    colors = [int(i) for i in colorsys.hsv_to_rgb(h, s, v)]
-                    bytes_ = getattr(command_handlers, handler)(command, *colors)
+                    bytes_ = getattr(command_handlers, handler)(command, *args, t=t)
                     bytes_ = helpers.merge_bytes(bytes_, suffix)
                     self._device_write(bytes_, report_type)
-                    time.sleep(0.02)
-                    if h > 0.99 or h < 0.01:
+                    time.sleep(SLEEP)
+                    t = t + c*(INCREMENT)
+                    if t > 0.99 or t < 0.01:
                         c = -c
-                    h = h + c*(0.01)
+
             else:
                 bytes_ = getattr(command_handlers, handler)(command, *args)
                 bytes_ = helpers.merge_bytes(bytes_, suffix)

--- a/rivalcfg/profiles/rival.py
+++ b/rivalcfg/profiles/rival.py
@@ -100,8 +100,8 @@ rival = {
             "cli": ["-g", "--logo-gradient"],
             "command": [0x08, 0x01],
             "is_gradient": True,
-            "value_type": "rgbcolor",
-            "default": "#FFFFFF",
+            "value_type": "hsvgradient",
+            "default": "0.1",
         },
 
         "set_wheel_color_gradient": {
@@ -109,8 +109,8 @@ rival = {
             "cli": ["-G", "--wheel-gradient"],
             "command": [0x08, 0x02],
             "is_gradient": True,
-            "value_type": "rgbcolor",
-            "default": "#FFFFFF",
+            "value_type": "hsvgradient",
+            "default": "0.1 1.0 255",
         },
 
         "save": {

--- a/rivalcfg/profiles/rival.py
+++ b/rivalcfg/profiles/rival.py
@@ -95,6 +95,24 @@ rival = {
             "default": "#FF1800"
         },
 
+        "set_logo_color_gradient": {
+            "description": "Set a gradient for the logo backlight",
+            "cli": ["-g", "--logo-gradient"],
+            "command": [0x08, 0x01],
+            "is_gradient": True,
+            "value_type": "rgbcolor",
+            "default": "#FFFFFF",
+        },
+
+        "set_wheel_color_gradient": {
+            "description": "Set a gradient for the wheel backlight",
+            "cli": ["-G", "--wheel-gradient"],
+            "command": [0x08, 0x02],
+            "is_gradient": True,
+            "value_type": "rgbcolor",
+            "default": "#FFFFFF",
+        },
+
         "save": {
             "description": "Save the configuration to the mouse memory",
             "cli": None,


### PR DESCRIPTION
Please do not merge this PR right now. It is far from complete. Adding it in case others want to use it before it's complete and/or give reviews.

Note: To use it right now, you have to issue an argument (any color) which is not used. Will be fixed later on.

For issue #3.

Currently done:

- [x] Added fixed gradient for wheel backlight
- [x] Added fixed gradient for logo backlight

Planned fixes:
- [ ] Add option to use gradient on wheel and logo simultaneously
- [ ] Make gradient variable (user can specify starting and ending colors)
- [ ] Improve code quality and reduce hackiness
- [ ] _Optional:_ write a systemd/other daemon file that will issue the command in background