### PR TITLE
Added experimental support for Rival 600

### DIFF
--- a/README.md
+++ b/README.md
@@ -235,34 +235,56 @@ SteelSeries Rival 500 Options (Experimental):
 SteelSeries Rival 600 Options (Experimental):
 
     -2 LEFT_STRIP_BOTTOM_COLOR, --lstrip-bottom-color=LEFT_STRIP_BOTTOM_COLOR
-                        Set the color of the left LED strip bottom section
-                        (e.g. red, #ff0000, ff0000, #f00, f00, default:
-                        #FF5200)
+                        Set the color(s) and effects of the left LED strip
+                        bottom section (e.g. red, #ff0000, ff0000, #f00, f00).
+                        If more than one value is specified, a color shifting
+                        effect is set (e.g. x,x,red,0,green,54,blue,54)
+                        syntax:
+                        time(ms),trigger_mask,color1,pos1,...,colorn,posn
     -1 LEFT_STRIP_MID_COLOR, --lstrip-mid-color=LEFT_STRIP_MID_COLOR
-                        Set the color of the left LED strip middle section
-                        (e.g. red, #ff0000, ff0000, #f00, f00, default:
-                        #FF5200)
+                        Set the color(s) and effects of the left LED strip
+                        middle section (e.g. red, #ff0000, ff0000, #f00, f00).
+                        If more than one value is specified, a color shifting
+                        effect is set (e.g. x,x,red,0,green,54,blue,54)
+                        syntax:
+                        time(ms),trigger_mask,color1,pos1,...,colorn,posn
     -0 LEFT_STRIP_TOP_COLOR, --lstrip-top-color=LEFT_STRIP_TOP_COLOR
-                        Set the color of the left LED strip upper section
-                        (e.g. red, #ff0000, ff0000, #f00, f00, default:
-                        #FF5200)
+                        Set the color(s) and effects of the left LED strip
+                        upper section (e.g. red, #ff0000, ff0000, #f00, f00).
+                        If more than one value is specified, a color shifting
+                        effect is set (e.g. x,x,red,0,green,54,blue,54)
+                        syntax:
+                        time(ms),trigger_mask,color1,pos1,...,colorn,posn
     -c LOGO_COLOR, --logo-color=LOGO_COLOR
-                        Set the logo backlight color (e.g. red, #ff0000,
-                        ff0000, #f00, f00, default: #FF5200)
+                        Set the logo backlight color(s) and effects (e.g. red,
+                        #ff0000, ff0000, #f00, f00). If more than one value is
+                        specified, a color shifting effect is set (e.g.
+                        x,x,red,0,green,54,blue,54) syntax:
+                        time(ms),trigger_mask,color1,pos1,...,colorn,posn
     -p POLLING_RATE, --polling-rate=POLLING_RATE
                         Set polling rate in Hz (values: 125, 250, 500, 1000,
                         default: 1000)
     -5 RIGHT_STRIP_BOTTOM_COLOR, --rstrip-bottom-color=RIGHT_STRIP_BOTTOM_COLOR
-                        Set the color of the right LED strip bottom section
-                        (e.g. red, #ff0000, ff0000, #f00, f00, default:
-                        #FF5200)
+                        Set the color(s) and effects of the right LED strip
+                        bottom section (e.g. red, #ff0000, ff0000, #f00, f00).
+                        If more than one value is specified, a color shifting
+                        effect is set (e.g. x,x,red,0,green,54,blue,54)
+                        syntax:
+                        time(ms),trigger_mask,color1,pos1,...,colorn,posn
     -4 RIGHT_STRIP_MID_COLOR, --rstrip-mid-color=RIGHT_STRIP_MID_COLOR
-                        Set the color of the right LED strip mid section (e.g.
-                        red, #ff0000, ff0000, #f00, f00, default: #FF5200)
+                        Set the color(s) and effects of the right LED strip
+                        mid section (e.g. red, #ff0000, ff0000, #f00, f00). If
+                        more than one value is specified, a color shifting
+                        effect is set (e.g. x,x,red,0,green,54,blue,54)
+                        syntax:
+                        time(ms),trigger_mask,color1,pos1,...,colorn,posn
     -3 RIGHT_STRIP_TOP_COLOR, --rstrip-top-color=RIGHT_STRIP_TOP_COLOR
-                        Set the color of the right LED strip upper section
-                        (e.g. red, #ff0000, ff0000, #f00, f00, default:
-                        #FF5200)
+                        Set the color(s) and effects of the right LED strip
+                        upper section (e.g. red, #ff0000, ff0000, #f00, f00).
+                        If more than one value is specified, a color shifting
+                        effect is set (e.g. x,x,red,0,green,54,blue,54)
+                        syntax:
+                        time(ms),trigger_mask,color1,pos1,...,colorn,posn
     -s SENSITIVITY1, --sensitivity1=SENSITIVITY1
                         Set sensitivity preset 1 (from 100 to 12000 in
                         increments of 100, default: 800)
@@ -270,8 +292,11 @@ SteelSeries Rival 600 Options (Experimental):
                         Set sensitivity preset 2 (from 100 to 12000 in
                         increments of 100, default: 1600)
     -C WHEEL_COLOR, --wheel-color=WHEEL_COLOR
-                        Set the wheel backlight color (e.g. red, #ff0000,
-                        ff0000, #f00, f00, default: #FF5200)
+                        Set the wheel backlight color(s) and effects (e.g.
+                        red, #ff0000, ff0000, #f00, f00). If more than one
+                        value is specified, a color shifting effect is set
+                        (e.g. x,x,red,0,green,54,blue,54) syntax:
+                        time(ms),trigger_mask,color1,pos1,...,colorn,posn
     -r, --reset         Reset all options to their factory values
 
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,7 @@ Experimental support:
 
 * SteelSeries Rival 310 _(1038:1720)_
 * SteelSeries Rival 500 _(1038:170e)_
+* SteelSeries Rival 600 _(1038:1724)_
 
 If you have trouble running this software, please open an issue on Github:
 
@@ -229,6 +230,48 @@ SteelSeries Rival 500 Options (Experimental):
     -T COLOR1 COLOR2 SPEED, --wheel-colorshift=COLOR1 COLOR2 SPEED
                         Set the wheel backlight color (e.g. red aqua 200,
                         ff0000 00ffff 200, default: #FF1800 #FF1800 200)
+    -r, --reset         Reset all options to their factory values
+
+SteelSeries Rival 600 Options (Experimental):
+
+    -2 LEFT_STRIP_BOTTOM_COLOR, --lstrip-bottom-color=LEFT_STRIP_BOTTOM_COLOR
+                        Set the color of the left LED strip bottom section
+                        (e.g. red, #ff0000, ff0000, #f00, f00, default:
+                        #FF5200)
+    -1 LEFT_STRIP_MID_COLOR, --lstrip-mid-color=LEFT_STRIP_MID_COLOR
+                        Set the color of the left LED strip middle section
+                        (e.g. red, #ff0000, ff0000, #f00, f00, default:
+                        #FF5200)
+    -0 LEFT_STRIP_TOP_COLOR, --lstrip-top-color=LEFT_STRIP_TOP_COLOR
+                        Set the color of the left LED strip upper section
+                        (e.g. red, #ff0000, ff0000, #f00, f00, default:
+                        #FF5200)
+    -c LOGO_COLOR, --logo-color=LOGO_COLOR
+                        Set the logo backlight color (e.g. red, #ff0000,
+                        ff0000, #f00, f00, default: #FF5200)
+    -p POLLING_RATE, --polling-rate=POLLING_RATE
+                        Set polling rate in Hz (values: 125, 250, 500, 1000,
+                        default: 1000)
+    -5 RIGHT_STRIP_BOTTOM_COLOR, --rstrip-bottom-color=RIGHT_STRIP_BOTTOM_COLOR
+                        Set the color of the right LED strip bottom section
+                        (e.g. red, #ff0000, ff0000, #f00, f00, default:
+                        #FF5200)
+    -4 RIGHT_STRIP_MID_COLOR, --rstrip-mid-color=RIGHT_STRIP_MID_COLOR
+                        Set the color of the right LED strip mid section (e.g.
+                        red, #ff0000, ff0000, #f00, f00, default: #FF5200)
+    -3 RIGHT_STRIP_TOP_COLOR, --rstrip-top-color=RIGHT_STRIP_TOP_COLOR
+                        Set the color of the right LED strip upper section
+                        (e.g. red, #ff0000, ff0000, #f00, f00, default:
+                        #FF5200)
+    -s SENSITIVITY1, --sensitivity1=SENSITIVITY1
+                        Set sensitivity preset 1 (from 100 to 12000 in
+                        increments of 100, default: 800)
+    -S SENSITIVITY2, --sensitivity2=SENSITIVITY2
+                        Set sensitivity preset 2 (from 100 to 12000 in
+                        increments of 100, default: 1600)
+    -C WHEEL_COLOR, --wheel-color=WHEEL_COLOR
+                        Set the wheel backlight color (e.g. red, #ff0000,
+                        ff0000, #f00, f00, default: #FF5200)
     -r, --reset         Reset all options to their factory values
 
 

--- a/rivalcfg/command_handlers.py
+++ b/rivalcfg/command_handlers.py
@@ -77,6 +77,58 @@ def rgbcolorshift_handler(command, colors, speed=200):
     return helpers.merge_bytes(command["command"], parsed_colors, speed)
 
 
+def rgbuniversal_handler(command, colors, positions, speed, triggers):
+    """ Returns command bytes from RGB color commands.
+    It crafts packets on a per mouse basis, by reading the format given
+    in "rgbuniversal_format" in the command dict. If a single color is given,
+    it creates a steady color command. If multiple colors are given, it creates
+    a colorshift command. If triggermask is nonzero, a reactive command is
+    created.
+
+    Arguments:
+    command -- the command description dict
+    colors -- the colors as an array of string (color name or hexadecimal RGB)
+    positions -- cumulative color positions as an array of hex strings
+    speed -- the colorshift cycle time as a string (milliseconds)
+    triggers -- trigger button mask as a hex string
+    """
+    colors = map(helpers.color_string_to_rgb, colors)
+    positions = map(lambda x: int(x, 16), positions)
+    speed = 5000 if speed == "x" else int(speed, 10)
+    triggers = 0 if triggers == "x" else int(triggers, 16)
+
+    rgb_format = command["rgbuniversal_format"]
+    header = [0] * rgb_format["header_len"]
+
+    for led_id in rgb_format["led_id"]:
+        header[led_id] = command["led_id"]
+
+    a, l = rgb_format["speed"], rgb_format["speed_len"]
+    speed = helpers.uint_to_little_endian_bytearray(speed, l)
+
+    header[a:a+l] = speed
+    header[rgb_format["repeat"]] = 1 if len(colors) == 1 or triggers > 0 else 0
+    header[rgb_format["triggers"]] = triggers
+    header[rgb_format["point_count"]] = len(colors) + 1
+
+    """ data segment format:
+    color1:color1:pos1:...:colorn:posn:color1:pos1
+    """
+    data = colors[0]
+
+    for color, pos in zip(colors, positions):
+        data = helpers.merge_bytes(data, color, pos)
+
+    remaining = 0xff - sum(positions)
+    if remaining < 0:
+        raise ValueError("The cumulative position offsets must be < 255 (is %d)" % sum(positions)) # noqa
+
+    # inserts first color at the end for smooth colorshifting
+    data = helpers.merge_bytes(data, colors[0], remaining)
+
+    return helpers.merge_bytes(command["command"], header, data)
+
+
 def range_handler(command, value):
     """Returns command bytes from range commands.
 

--- a/rivalcfg/command_handlers.py
+++ b/rivalcfg/command_handlers.py
@@ -94,8 +94,8 @@ def rgbuniversal_handler(command, colors, positions, speed, triggers):
     """
     colors = map(helpers.color_string_to_rgb, colors)
     positions = map(lambda x: int(x, 16), positions)
-    speed = 5000 if speed == "x" else int(speed, 10)
-    triggers = 0 if triggers == "x" else int(triggers, 16)
+    speed = 5000 if speed.lower() == "x" else int(speed, 10)
+    triggers = 0 if triggers.lower() == "x" else int(triggers, 16)
 
     rgb_format = command["rgbuniversal_format"]
     header = [0] * rgb_format["header_len"]
@@ -103,17 +103,16 @@ def rgbuniversal_handler(command, colors, positions, speed, triggers):
     for led_id in rgb_format["led_id"]:
         header[led_id] = command["led_id"]
 
-    a, l = rgb_format["speed"], rgb_format["speed_len"]
-    speed = helpers.uint_to_little_endian_bytearray(speed, l)
+    speed_pos, speed_len = rgb_format["speed"], rgb_format["speed_len"]
+    speed = helpers.uint_to_little_endian_bytearray(speed, speed_len)
 
-    header[a:a+l] = speed
+    header[speed_pos:speed_pos + speed_len] = speed
     header[rgb_format["repeat"]] = 1 if len(colors) == 1 or triggers > 0 else 0
     header[rgb_format["triggers"]] = triggers
     header[rgb_format["point_count"]] = len(colors) + 1
 
-    """ data segment format:
-    color1:color1:pos1:...:colorn:posn:color1:pos1
-    """
+    # data segment format:
+    # color1:color1:pos1:...:colorn:posn:color1:pos1
     data = colors[0]
 
     for color, pos in zip(colors, positions):

--- a/rivalcfg/data/99-steelseries-rival.rules
+++ b/rivalcfg/data/99-steelseries-rival.rules
@@ -34,6 +34,10 @@ SUBSYSTEM=="usb", ATTRS{idVendor}=="1038", ATTRS{idProduct}=="1720", MODE="0666"
 SUBSYSTEM=="hidraw", ATTRS{idVendor}=="1038", ATTRS{idProduct}=="170E", MODE="0666"
 SUBSYSTEM=="usb", ATTRS{idVendor}=="1038", ATTRS{idProduct}=="170E", MODE="0666"
 
+#SteelSeries Rival 600
+SUBSYSTEM=="hidraw", ATTRS{idVendor}=="1038", ATTRS{idProduct}=="1724", MODE="0666"
+SUBSYSTEM=="usb", ATTRS{idVendor}=="1038", ATTRS{idProduct}=="1724", MODE="0666"
+
 # SteelSeries Heroes of the Storm (Sensei Raw)
 SUBSYSTEM=="hidraw", ATTRS{idVendor}=="1038", ATTRS{idProduct}=="1390", MODE="0666"
 SUBSYSTEM=="usb", ATTRS{idVendor}=="1038", ATTRS{idProduct}=="1390", MODE="0666"

--- a/rivalcfg/helpers.py
+++ b/rivalcfg/helpers.py
@@ -70,7 +70,7 @@ def is_hex(string):
     try:
         int(string, 16)
         return True
-    except:
+    except ValueError:
         return False
 
 

--- a/rivalcfg/helpers.py
+++ b/rivalcfg/helpers.py
@@ -66,6 +66,14 @@ def is_color(string):
     return False
 
 
+def is_hex(string):
+    try:
+        int(string, 16)
+        return True
+    except:
+        return False
+
+
 def color_string_to_rgb(color_string):
     """Converts the color string into an RGB tuple.
 

--- a/rivalcfg/mouse.py
+++ b/rivalcfg/mouse.py
@@ -72,6 +72,14 @@ class Mouse:
         if "suffix" in command:
             suffix = command["suffix"]
 
+        if command["value_type"] == "rgbuniversal":
+            if "rgbuniversal_format" in self.profile:
+                debug.log("rgbuniversal_format found")
+                command["rgbuniversal_format"] = \
+                    self.profile["rgbuniversal_format"]
+            else:
+                raise Exception("rgbuniversal value type was specified, but the format is not defined for %s" % self.profile["name"]) # noqa
+
         if not hasattr(command_handlers, handler):
             raise Exception("There is not handler for the '%s' value type" % command["value_type"])  # noqa
 

--- a/rivalcfg/profiles/__init__.py
+++ b/rivalcfg/profiles/__init__.py
@@ -7,6 +7,7 @@ from .rival300csgofadeedition import rival300csgofadeedition
 from .rival300csgohyperbeastedition import rival300csgohyperbeastedition
 from .rival300hpomen import rival300hpomen
 from .rival500 import rival500
+from .rival600 import rival600
 from .hotssenseiraw import hotssenseiraw
 
 mice_profiles = [
@@ -19,5 +20,6 @@ mice_profiles = [
     rival300hpomen,
     rival310,
     rival500,
+    rival600,
     hotssenseiraw,
 ]

--- a/rivalcfg/profiles/rival600.py
+++ b/rivalcfg/profiles/rival600.py
@@ -1,0 +1,173 @@
+from .. import usbhid
+
+# TODO: the color transform functions are ugly and lacking R&D
+
+""" Function: solid_color_transformer
+Replicates solid color commands of official tool:
+      led            led                                               solid          length
+|cmd--|^^|unkown1----|^^|speed|unknown2---------------------------------|^^|unknown3---|^^|color---|--clr1--|p1|--clr2--|p2|
+|05:00:04:2d:00:b4:00:04:10:27:00:00:00:00:00:00:00:00:00:00:00:00:00:00:01:00:00:00:00:02:ff:4d:00:ff:4d:00:00:ff:4d:00:ff|
+      |partial-------------------------------------------------------------------------|this function----------------------|
+
+This function should not be called outside of make_transform()
+"""
+def solid_color_transformer(partial):
+    def transform(r, g, b):
+        length = [0x02]
+        color = [r, g, b]
+        color_chain = color + color + [0x0] + color + [0xff]
+        return partial + length + color_chain
+    return transform
+
+""" Function: make_transform
+Arguments:
+    led   (int)         : The led id to change color.
+    solid (boolean)     : Wether it should be a solid color or color shifting.
+    aux_builder (fn(x)) : A function which returns a "value_transform"-compliant 
+                        : fn, for completing the partial data made by this fn.
+    speed               : The rate of change when using color shift.
+    u1..3               : Data segments of unknown meaning. Needs more R&D.
+"""
+def make_transform(led, solid, aux_builder, speed=[0x10, 0x27], u1=[0]*4, \
+                    u2=[0]*14, u3=[0]*4):
+    solid = [1] if solid else [0]
+    led = [led]
+    partial = led + u1 + led + speed + u2 + solid + u3
+    return aux_builder(partial)
+
+rival600 = {
+    "name": "SteelSeries Rival 600 (Experimental)",
+
+    "vendor_id": 0x1038,
+    "product_id": 0x1724,
+    "interface_number": 0,
+
+    "commands": {
+
+        "set_sensitivity1": {
+            "description": "Set sensitivity preset 1",
+            "cli": ["-s", "--sensitivity1"],
+            "command": [0x03, 0x00, 0x01],
+            "suffix": [0x00, 0x42],
+            "value_type": "range",
+            "range_min": 100,
+            "range_max": 12000,
+            "range_increment": 100,
+            "value_transform": lambda x: int((x / 100) - 1),
+            "default": 800,
+        },
+        "set_sensitivity2": {
+            "description": "Set sensitivity preset 2",
+            "cli": ["-S", "--sensitivity2"],
+            "command": [0x03, 0x00, 0x02],
+            "suffix": [0x00, 0x42],
+            "value_type": "range",
+            "range_min": 100,
+            "range_max": 12000,
+            "range_increment": 100,
+            "value_transform": lambda x: int((x / 100) - 1),
+            "default": 1600,
+        },
+
+        "set_polling_rate": {
+            "description": "Set polling rate in Hz",
+            "cli": ["-p", "--polling-rate"],
+            "command": [0x04, 0x00],
+            "value_type": "choice",
+            "choices": {
+                125: 0x04,
+                250: 0x03,
+                500: 0x02,
+                1000: 0x01,
+            },
+            "default": 1000,
+        },
+
+        "set_wheel_color": {
+            "description": "Set the wheel backlight color",
+            "cli": ["-C", "--wheel-color"],
+            "command": [0x05, 0x00],
+            "report_type": usbhid.HID_REPORT_TYPE_FEATURE,
+            "value_type": "rgbcolor",
+            "value_transform": make_transform(0, True, solid_color_transformer),
+            "default": "#FF5200"
+        },
+
+        "set_logo_color": {
+            "description": "Set the logo backlight color",
+            "cli": ["-c", "--logo-color"],
+            "command": [0x05, 0x00],
+            "report_type": usbhid.HID_REPORT_TYPE_FEATURE,
+            "value_type": "rgbcolor",
+            "value_transform": make_transform(1, True, solid_color_transformer),
+            "default": "#FF5200"
+        },
+
+        "set_left_strip_top_color": {
+            "description": "Set the color of the left LED strip upper section",
+            "cli": ["-0", "--lstrip-top-color"],
+            "command": [0x05, 0x00],
+            "report_type": usbhid.HID_REPORT_TYPE_FEATURE,
+            "value_type": "rgbcolor",
+            "value_transform": make_transform(2, True, solid_color_transformer),
+            "default": "#FF5200"
+        },
+
+        "set_left_strip_mid_color": {
+            "description": "Set the color of the left LED strip middle section",
+            "cli": ["-1", "--lstrip-mid-color"],
+            "command": [0x05, 0x00],
+            "report_type": usbhid.HID_REPORT_TYPE_FEATURE,
+            "value_type": "rgbcolor",
+            "value_transform": make_transform(4, True, solid_color_transformer),
+            "default": "#FF5200"
+        },
+
+        "set_left_strip_bottom_color": {
+            "description": "Set the color of the left LED strip bottom section",
+            "cli": ["-2", "--lstrip-bottom-color"],
+            "command": [0x05, 0x00],
+            "report_type": usbhid.HID_REPORT_TYPE_FEATURE,
+            "value_type": "rgbcolor",
+            "value_transform": make_transform(6, True, solid_color_transformer),
+            "default": "#FF5200"
+        },
+
+        "set_right_strip_top_color": {
+            "description": "Set the color of the right LED strip upper section",
+            "cli": ["-3", "--rstrip-top-color"],
+            "command": [0x05, 0x00],
+            "report_type": usbhid.HID_REPORT_TYPE_FEATURE,
+            "value_type": "rgbcolor",
+            "value_transform": make_transform(3, True, solid_color_transformer),
+            "default": "#FF5200"
+        },
+
+        "set_right_strip_mid_color": {
+            "description": "Set the color of the right LED strip mid section",
+            "cli": ["-4", "--rstrip-mid-color"],
+            "command": [0x05, 0x00],
+            "report_type": usbhid.HID_REPORT_TYPE_FEATURE,
+            "value_type": "rgbcolor",
+            "value_transform": make_transform(5, True, solid_color_transformer),
+            "default": "#FF5200"
+        },
+
+        "set_right_strip_bottom_color": {
+            "description": "Set the color of the right LED strip bottom section",
+            "cli": ["-5", "--rstrip-bottom-color"],
+            "command": [0x05, 0x00],
+            "report_type": usbhid.HID_REPORT_TYPE_FEATURE,
+            "value_type": "rgbcolor",
+            "value_transform": make_transform(7, True, solid_color_transformer),
+            "default": "#FF5200"
+        },
+
+        "save": {
+            "description": "Save the configuration to the mouse memory",
+            "cli": None,
+            "command": [0x09, 0x00],
+            "value_type": None,
+        },
+    }
+}


### PR DESCRIPTION
EDIT2: see my other comment below
### General
Added support for sensitivity, polling rate, solid colors for all LEDs and saving for the Rival 600.

~~Except for udev rules and initial loading of profiles, I have kept all new code inside _rival600.py_ as to not clutter central code files. This may need some refactoring.~~

One quirk of the 600 is that it doesn't have separate commands for solid colors and color effects. They are stringed together in one big command, the 0x0500 command.

There are some bytes that I haven't been able to identify their purpose. More experimentation is needed to understand the color protocol fully. I have attached my notes on the protocol:

~~[rival600_protocol.txt](https://github.com/flozz/rivalcfg/files/2267722/rival600_protocol.txt)~~

### Todos

- Understand color protocol (maybe [pr43](https://github.com/flozz/rivalcfg/pull/43) has some clues)
- ~~Check for side effects as consequence of not fully understanding the color protocol~~
- ~~Check if color setting code can be simplified (again, because of not fully understanding the color protocol currently)~~
- ~~Add color shift support~~
- Add button configuration support
- ~~Consider if some central code needs modifications to accommodate the 600 and similar mice~~

~~EDIT1: although this works for my Rival 600, the code is arguably unrefined. Unsure if this should be considered for merging now as experimental support, or be kept open while refining the code (pr43 has some really interesting insights and similarities) and have discussions regarding this class of mice.~~