### PR TITLE
Fixes an issue when running on python 3

### DIFF
--- a/rivalcfg/command_handlers.py
+++ b/rivalcfg/command_handlers.py
@@ -92,7 +92,7 @@ def rgbuniversal_handler(command, colors, positions, speed, triggers):
     speed -- the colorshift cycle time as a string (milliseconds)
     triggers -- trigger button mask as a hex string
     """
-    colors = map(helpers.color_string_to_rgb, colors)
+    colors = list(map(helpers.color_string_to_rgb, colors))
     positions = map(lambda x: int(x, 16), positions)
     speed = 5000 if speed.lower() == "x" else int(speed, 10)
     triggers = 0 if triggers.lower() == "x" else int(triggers, 16)


### PR DESCRIPTION
In python3 the map function returns a generator rather than a list.
This generator has no len() function, causing an error. By
explicitly casting it into a list we use a bit more ram, but it
then has a known length

Fixes #61 