### PR TITLE
added sensitivity commands from rival600 to rival500

### DIFF
--- a/rivalcfg/profiles/rival500.py
+++ b/rivalcfg/profiles/rival500.py
@@ -10,6 +10,32 @@ rival500 = {
 
     "commands": {
 
+        "set_sensitivity1": {
+            "description": "Set sensitivity preset 1",
+            "cli": ["-s", "--sensitivity1"],
+            "command": [0x03, 0x00, 0x01],
+            "suffix": [0x00, 0x42],
+            "value_type": "range",
+            "range_min": 100,
+            "range_max": 12000,
+            "range_increment": 100,
+            "value_transform": lambda x: int((x / 100) - 1),
+            "default": 800,
+        },
+
+        "set_sensitivity2": {
+            "description": "Set sensitivity preset 2",
+            "cli": ["-S", "--sensitivity2"],
+            "command": [0x03, 0x00, 0x02],
+            "suffix": [0x00, 0x42],
+            "value_type": "range",
+            "range_min": 100,
+            "range_max": 12000,
+            "range_increment": 100,
+            "value_transform": lambda x: int((x / 100) - 1),
+            "default": 1600,
+        },
+
         "set_logo_color": {
             "description": "Set the logo backlight color",
             "cli": ["-c", "--logo-color"],


### PR DESCRIPTION
The sensitivity commands for the Rival 600 worked as-is on my machine with my Rival 500. @Thiblizz had posted [some screen caps](https://github.com/flozz/rivalcfg/issues/32#issuecomment-304448110) in #32 that indicated that the commands had the same format, and I can happily confirm that they are working perfectly with my hardware.