### PR TITLE
Fixed: idVendor and idProduct must use lower case

### DIFF
--- a/rivalcfg/data/99-steelseries-rival.rules
+++ b/rivalcfg/data/99-steelseries-rival.rules
@@ -19,8 +19,8 @@ SUBSYSTEM=="hidraw", ATTRS{idVendor}=="1038", ATTRS{idProduct}=="1394", MODE="06
 SUBSYSTEM=="usb", ATTRS{idVendor}=="1038", ATTRS{idProduct}=="1394", MODE="0666"
 
 # SteelSeries Rival 300 CS:GO Hyperbeast Edition
-SUBSYSTEM=="hidraw", ATTRS{idVendor}=="1038", ATTRS{idProduct}=="171A", MODE="0666"
-SUBSYSTEM=="usb", ATTRS{idVendor}=="1038", ATTRS{idProduct}=="171A", MODE="0666"
+SUBSYSTEM=="hidraw", ATTRS{idVendor}=="1038", ATTRS{idProduct}=="171a", MODE="0666"
+SUBSYSTEM=="usb", ATTRS{idVendor}=="1038", ATTRS{idProduct}=="171a", MODE="0666"
 
 # SteelSeries Rival 300 HP Omen Edition
 SUBSYSTEM=="hidraw", ATTRS{idVendor}=="1038", ATTRS{idProduct}=="1718", MODE="0666"
@@ -31,8 +31,8 @@ SUBSYSTEM=="hidraw", ATTRS{idVendor}=="1038", ATTRS{idProduct}=="1720", MODE="06
 SUBSYSTEM=="usb", ATTRS{idVendor}=="1038", ATTRS{idProduct}=="1720", MODE="0666"
 
 # SteelSeries Rival 500
-SUBSYSTEM=="hidraw", ATTRS{idVendor}=="1038", ATTRS{idProduct}=="170E", MODE="0666"
-SUBSYSTEM=="usb", ATTRS{idVendor}=="1038", ATTRS{idProduct}=="170E", MODE="0666"
+SUBSYSTEM=="hidraw", ATTRS{idVendor}=="1038", ATTRS{idProduct}=="170e", MODE="0666"
+SUBSYSTEM=="usb", ATTRS{idVendor}=="1038", ATTRS{idProduct}=="170e", MODE="0666"
 
 #SteelSeries Rival 600
 SUBSYSTEM=="hidraw", ATTRS{idVendor}=="1038", ATTRS{idProduct}=="1724", MODE="0666"


### PR DESCRIPTION
The udev rules for the Rival 500 (and presumably also the "SteelSeries Rival 300 CS:GO Hyperbeast Edition" though I don't have the hardware) don't match the alphabetic case that sysfs will report the `idVendor` and `idProduct` attributes with, and as such the rules will not be applied. Without this change, rivalcfg must be run as root to talk to these devices.

Original Commit:
-----
Per man udev(7): 

### `ATTR{filename}`, `SYSCTL{kernel parameter }`
Match sysfs attribute values of the event device. Trailing whitespace in the attribute values is ignored unless the specified match value itself contains trailing whitespace. Match a kernel parameter value.

udev reads and matches attributes from /sys/devices as strings, and as such these attributes are case sensitive.

I couldn't find documentation explicitly stating that these were lower case as a rule, but I tracked down [the exact line in the linux kernel](https://github.com/torvalds/linux/blob/7876320f88802b22d4e2daf7eb027dd14175a0f8/drivers/usb/core/sysfs.c#L718) where this property is written and, sure enough, they use `%04x` format strings, which means these are hard-coded to lower case.