### PR TITLE
Added Rival 710 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -273,7 +273,7 @@ SteelSeries Rival 600 Options (Experimental):
                         time(ms),trigger_mask,color1,pos1,...,colorn,posn
     -r, --reset         Reset all options to their factory values
     
-SteelSeries Rival 710 Options:
+SteelSeries Rival 710 Options (Experimental):
 
     -s SENSITIVITY1, --sensitivity1=SENSITIVITY1
                         Set sensitivity preset 1 (from 100 to 12000 in

--- a/README.md
+++ b/README.md
@@ -21,7 +21,6 @@ Supported mice:
 * SteelSeries Rival 300 CS:GO Hyperbeast Edition _(1038:171a)_
 * SteelSeries Rival 300 Dota 2 Edition _(1038:1392)_
 * SteelSeries Rival 300 HP Omen Edition _(1038:1718)_
-* SteelSeries Rival 710 _(1038:1730)_
 * SteelSeries Heroes of the Storm (Sensei Raw) _(1038:1390)_
 * SteelSeries Kana V2 _(1038:137a)_
 
@@ -30,6 +29,7 @@ Experimental support:
 * SteelSeries Rival 310 _(1038:1720)_
 * SteelSeries Rival 500 _(1038:170e)_
 * SteelSeries Rival 600 _(1038:1724)_
+* SteelSeries Rival 710 _(1038:1730)_
 
 If you have trouble running this software, please open an issue on Github:
 

--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Supported mice:
 * SteelSeries Rival 300 CS:GO Hyperbeast Edition _(1038:171a)_
 * SteelSeries Rival 300 Dota 2 Edition _(1038:1392)_
 * SteelSeries Rival 300 HP Omen Edition _(1038:1718)_
+* SteelSeries Rival 710 _(1038:1730)_
 * SteelSeries Heroes of the Storm (Sensei Raw) _(1038:1390)_
 * SteelSeries Kana V2 _(1038:137a)_
 
@@ -271,6 +272,21 @@ SteelSeries Rival 600 Options (Experimental):
                         (e.g. x,x,red,0,green,54,blue,54) syntax:
                         time(ms),trigger_mask,color1,pos1,...,colorn,posn
     -r, --reset         Reset all options to their factory values
+    
+SteelSeries Rival 710 Options:
+
+    -s SENSITIVITY1, --sensitivity1=SENSITIVITY1
+                        Set sensitivity preset 1 (from 100 to 12000 in
+                        increments of 100, default: 800)
+    -S SENSITIVITY2, --sensitivity2=SENSITIVITY2
+                        Set sensitivity preset 2 (from 100 to 12000 in
+                        increments of 100, default: 1600)
+    -c LOGO_COLOR, --logo-color=LOGO_COLOR
+                        Set the logo backlight color (e.g. red, #ff0000,
+                        ff0000, #f00, f00, default: #FF1800)
+    -C WHEEL_COLOR, --wheel-color=WHEEL_COLOR
+                        Set the wheel backlight color (e.g. red, #ff0000,
+                        ff0000, #f00, f00, default: #FF1800)
 
 SteelSeries Kana V2 Options:
 

--- a/rivalcfg/data/99-steelseries-rival.rules
+++ b/rivalcfg/data/99-steelseries-rival.rules
@@ -50,6 +50,10 @@ SUBSYSTEM=="usb", ATTRS{idVendor}=="1038", ATTRS{idProduct}=="170e", MODE="0666"
 SUBSYSTEM=="hidraw", ATTRS{idVendor}=="1038", ATTRS{idProduct}=="1724", MODE="0666"
 SUBSYSTEM=="usb", ATTRS{idVendor}=="1038", ATTRS{idProduct}=="1724", MODE="0666"
 
+#SteelSeries Rival 710
+SUBSYSTEM=="hidraw", ATTRS{idVendor}=="1038", ATTRS{idProduct}=="1730", MODE="0666"
+SUBSYSTEM=="usb", ATTRS{idVendor}=="1038", ATTRS{idProduct}=="1730", MODE="0666"
+
 # SteelSeries Heroes of the Storm (Sensei Raw)
 SUBSYSTEM=="hidraw", ATTRS{idVendor}=="1038", ATTRS{idProduct}=="1390", MODE="0666"
 SUBSYSTEM=="usb", ATTRS{idVendor}=="1038", ATTRS{idProduct}=="1390", MODE="0666"

--- a/rivalcfg/profiles/__init__.py
+++ b/rivalcfg/profiles/__init__.py
@@ -11,6 +11,7 @@ from .rival300hpomen import rival300hpomen
 from .rival310 import rival310
 from .rival500 import rival500
 from .rival600 import rival600
+from .rival710 import rival710
 from .hotssenseiraw import hotssenseiraw
 from .kanav2 import kanav2
 
@@ -28,6 +29,7 @@ mice_profiles = [
     rival310,
     rival500,
     rival600,
+    rival710,
     hotssenseiraw,
     kanav2,
 ]

--- a/rivalcfg/profiles/rival710.py
+++ b/rivalcfg/profiles/rival710.py
@@ -1,0 +1,68 @@
+
+from .. import usbhid
+
+rival710 = {
+    "name": "SteelSeries Rival 710",
+
+    "vendor_id": 0x1038,
+    "product_id": 0x1730,
+    "interface_number": 0,
+
+    "commands": {
+
+        "set_sensitivity1": {
+            "description": "Set sensitivity preset 1",
+            "cli": ["-s", "--sensitivity1"],
+            "command": [0x03, 0x00, 0x01],
+            "suffix": [0x00, 0x42],
+            "value_type": "range",
+            "range_min": 100,
+            "range_max": 12000,
+            "range_increment": 100,
+            "value_transform": lambda x: int((x / 100) - 1),
+            "default": 800,
+        },
+
+        "set_sensitivity2": {
+            "description": "Set sensitivity preset 2",
+            "cli": ["-S", "--sensitivity2"],
+            "command": [0x03, 0x00, 0x02],
+            "suffix": [0x00, 0x42],
+            "value_type": "range",
+            "range_min": 100,
+            "range_max": 12000,
+            "range_increment": 100,
+            "value_transform": lambda x: int((x / 100) - 1),
+            "default": 1600,
+        },
+        
+        "set_logo_color": {
+            "description": "Set the logo backlight color",
+            "cli": ["-c", "--logo-color"],
+            "command": [0x05, 0x00, 0x00],
+            "suffix": [0xFF, 0x32, 0xC8, 0xC8, 0x00, 0x00, 0x01],
+            "report_type": usbhid.HID_REPORT_TYPE_FEATURE,  # wValue = 0x0300
+            "value_type": "rgbcolor",
+            "default": "#FF1800"
+        },
+        
+        "set_wheel_color": {
+            "description": "Set the wheel backlight color",
+            "cli": ["-C", "--wheel-color"],
+            "command": [0x05, 0x00, 0x01],
+            "suffix": [0xFF, 0x32, 0xC8, 0xC8, 0x00, 0x01, 0x01],
+            "report_type": usbhid.HID_REPORT_TYPE_FEATURE,  # wValue = 0x0300
+            "value_type": "rgbcolor",
+            "default": "#FF1800"
+        },
+
+        "save": {
+            "description": "Save the configuration to the mouse memory",
+            "cli": None,
+            "command": [0x09, 0x00],
+            "value_type": None,
+        },
+
+    },
+
+}

--- a/rivalcfg/profiles/rival710.py
+++ b/rivalcfg/profiles/rival710.py
@@ -35,7 +35,7 @@ rival710 = {
             "value_transform": lambda x: int((x / 100) - 1),
             "default": 1600,
         },
-        
+
         "set_logo_color": {
             "description": "Set the logo backlight color",
             "cli": ["-c", "--logo-color"],
@@ -45,7 +45,7 @@ rival710 = {
             "value_type": "rgbcolor",
             "default": "#FF1800"
         },
-        
+
         "set_wheel_color": {
             "description": "Set the wheel backlight color",
             "cli": ["-C", "--wheel-color"],

--- a/rivalcfg/profiles/rival710.py
+++ b/rivalcfg/profiles/rival710.py
@@ -2,7 +2,7 @@
 from .. import usbhid
 
 rival710 = {
-    "name": "SteelSeries Rival 710",
+    "name": "SteelSeries Rival 710 (Experimental)",
 
     "vendor_id": 0x1038,
     "product_id": 0x1730,


### PR DESCRIPTION
Hi,
I have added support for my Rival 710. 4 functions (set_sensitivity1, set_sensitivity2, set_logo_color, set_wheel_color) works, tested on Arch Linux. Unfortunately colorshift doesn't work. Maybe in the future I will try to introduce more functions (e.g. setting the image on the mouse screen or setting vibrations) but currently it's too hard for me.