### PR TITLE
Add support for SteelSeries Rival 105

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,7 @@ Experimental support:
 * SteelSeries Rival 600 _(1038:1724)_
 * SteelSeries Rival 710 _(1038:1730)_
 * SteelSeries Sensei 310 _(1038:1722)_
+* SteelSeries Rival 105 _(1038:1814)_
 
 If you have trouble running this software, please open an issue on Github:
 

--- a/rivalcfg/data/99-steelseries-rival.rules
+++ b/rivalcfg/data/99-steelseries-rival.rules
@@ -65,3 +65,7 @@ SUBSYSTEM=="usb", ATTRS{idVendor}=="1038", ATTRS{idProduct}=="1722", MODE="0666"
 # SteelSeries Kana V2
 SUBSYSTEM=="hidraw", ATTRS{idVendor}=="1038", ATTRS{idProduct}=="137a", MODE="0666"
 SUBSYSTEM=="usb", ATTRS{idVendor}=="1038", ATTRS{idProduct}=="137a", MODE="0666"
+
+# SteelSeries Rival 105
+SUBSYSTEM=="hidraw", ATTRS{idVendor}=="1038", ATTRS{idProduct}=="1814", MODE="0666"
+SUBSYSTEM=="usb", ATTRS{idVendor}=="1038", ATTRS{idProduct}=="1814", MODE="0666"

--- a/rivalcfg/profiles/__init__.py
+++ b/rivalcfg/profiles/__init__.py
@@ -1,5 +1,6 @@
 from .rival import rival
 from .rival100 import rival100
+from .rival105 import rival105
 from .rival100dota2edition import rival100dota2edition
 from .rival110 import rival110
 from .rival300 import rival300
@@ -19,6 +20,7 @@ from .kanav2 import kanav2
 mice_profiles = [
     rival,
     rival100,
+    rival105,
     rival100dota2edition,
     rival110,
     rival300,

--- a/rivalcfg/profiles/rival105.py
+++ b/rivalcfg/profiles/rival105.py
@@ -1,0 +1,12 @@
+from .rival100 import rival100
+
+rival105 = {
+    "name": "SteelSeries Rival 105 (Experimental)",
+
+    "vendor_id": 0x1038,
+    "product_id": 0x1814,
+    "interface_number": 0,
+
+    "commands": rival100["commands"]
+
+}


### PR DESCRIPTION
Commands of SteelSeries 100 work for this model, but options --btn6-action and --sensitivity2 seems to have no effect 