### PR TITLE
Rival 100: add support for querying firmware version

### DIFF
--- a/rivalcfg/devices/rival100.py
+++ b/rivalcfg/devices/rival100.py
@@ -133,4 +133,9 @@ profile = {
         "report_type": usbhid.HID_REPORT_TYPE_OUTPUT,
         "command": [0x09, 0x00],
     },
+    "firmware_version": {
+        "report_type": usbhid.HID_REPORT_TYPE_OUTPUT,
+        "command": [0x10, 0x00],
+        "response_length": 2,
+    },
 }


### PR DESCRIPTION
I kind of doubt this mouse has different firmware versions, but why not.
Mine is v0.101 by the way.
It probably works the same way on Rival 110.