### PR TITLE
Improve CLI startup time

### DIFF
--- a/rivalcfg/cli.py
+++ b/rivalcfg/cli.py
@@ -12,7 +12,6 @@ import argparse
 from . import handlers
 from . import devices
 from . import udev
-from . import debug
 from .version import VERSION
 
 
@@ -80,6 +79,7 @@ class PrintDebugAction(argparse.Action):
     """Prints debug informations and exit."""
 
     def __call__(self, parser, namespace, value, option_string=None):
+        from . import debug
         print(debug.get_debug_info())
         sys.exit(0)
 


### PR DESCRIPTION
Program startup time was really slow. After inspecting it with `-Ximporttime` it turned out to be pulling in a lot of unnecessary packages from `pkg_resources` responsible only for debug functionality.

Solution: reduce the scope of the debug import.

Note that this type of optimization is more of a hack than a solution, but considering it significantly improves startup time for the 99%+ of use cases it is worth implementing.

Before the patch:
```
$ time python3.10 -m rivalcfg --help > /dev/null

real	0m0,156s
user	0m0,125s
sys	0m0,023s
```

After the patch:
```
$ time python3.10 -m rivalcfg --help > /dev/null

real	0m0,069s
user	0m0,050s
sys	0m0,011s
```