### PR TITLE
Improve CLI startup time

### DIFF
--- a/rivalcfg/debug.py
+++ b/rivalcfg/debug.py
@@ -49,6 +49,7 @@ def _get_rivalcfg_info():
 
 def _get_python_info():
     from pkg_resources import get_distribution
+
     result = _make_title("Python")
     result += "Python version: %d.%d.%d\n" % sys.version_info[:3]
     result += "HIDAPI version: %s\n" % get_distribution("hidapi").version

--- a/rivalcfg/debug.py
+++ b/rivalcfg/debug.py
@@ -3,7 +3,6 @@ import os.path
 import platform
 
 import hid
-from pkg_resources import get_distribution
 from .version import VERSION
 from . import udev
 from .mouse import get_mouse
@@ -49,6 +48,7 @@ def _get_rivalcfg_info():
 
 
 def _get_python_info():
+    from pkg_resources import get_distribution
     result = _make_title("Python")
     result += "Python version: %d.%d.%d\n" % sys.version_info[:3]
     result += "HIDAPI version: %s\n" % get_distribution("hidapi").version


### PR DESCRIPTION
Program startup time was really slow. After inspecting it with `-Ximporttime` it turned out to be pulling in a lot of unnecessary packages from `pkg_resources` responsible only for debug functionality.

Solution: reduce the scope of the debug import.

Note that this type of optimization is more of a hack than a solution, but considering it significantly improves startup time for the 99%+ of use cases it is worth implementing.

Before the patch:
```
$ time python3.10 -m rivalcfg --help > /dev/null

real	0m0,156s
user	0m0,125s
sys	0m0,023s

$ time python3.10 -m rivalcfg -s 800

real	0m0,260s
user	0m0,129s
sys	0m0,021s
```

After the patch:
```
$ time python3.10 -m rivalcfg --help > /dev/null

real	0m0,069s
user	0m0,050s
sys	0m0,011s

$ time python3.10 -m rivalcfg -s 800

real	0m0,185s
user	0m0,060s
sys	0m0,015s
```