### PR TITLE
add usage_page parameter to specify device more precisely

### DIFF
--- a/rivalcfg/mouse.py
+++ b/rivalcfg/mouse.py
@@ -33,7 +33,8 @@ def get_mouse(vendor_id=0x1038, product_id=None):
         profile,
     )
 
-    hid_device = usbhid.open_device(vendor_id, product_id, profile["endpoint"])
+    hid_device = usbhid.open_device(vendor_id, product_id, profile["endpoint"],
+                                    usage_page=0xffc0)
 
     return Mouse(hid_device, profile, settings)
 
@@ -64,7 +65,7 @@ class Mouse:
     >>> profile = devices.get_profile(vendor_id=0x1038, product_id=0x1702)
     >>> settings = get_mouse_settings(0x1038, 0x1702, profile)
     >>> Mouse(
-    ...     usbhid.open_device(vendor_id=0x1038, product_id=0x1702, endpoint=0),
+    ...     usbhid.open_device(vendor_id=0x1038, product_id=0x1702, endpoint=0, usage_page=0xffc0),
     ...     profile,
     ...     settings,
     ... )

--- a/rivalcfg/usbhid.py
+++ b/rivalcfg/usbhid.py
@@ -52,13 +52,14 @@ def is_device_plugged(vendor_id, product_id):
     return len(hid.enumerate(vendor_id, product_id)) > 0
 
 
-def open_device(vendor_id, product_id, endpoint):
+def open_device(vendor_id, product_id, endpoint, usage_page=None):
     """Opens and returns the HID device
 
     :param int vendor_id: The vendor id of the device (e.g. ``0x1038``)).
     :param int product_id: The product id of the device (e.g. ``0x1710``).
     :param int endpoint: The number of the endpoint to open on the device (e.g.
                          ``0``).
+    :param int usage_page: The HID usage page of the device (e.g. ``0xffc0``).
 
     :raise DeviceNotFound: The requested device is not plugged to the computer
                            or it does not provide the requested endpoint.
@@ -83,7 +84,9 @@ def open_device(vendor_id, product_id, endpoint):
 
     # Search the device
     for interface in hid.enumerate(vendor_id, product_id):
-        if interface["interface_number"] == endpoint:
+        if (usage_page is None or interface["usage_page"] == usage_page) and (
+            interface["interface_number"] == endpoint
+        ):
             path = interface["path"]
             break
 


### PR DESCRIPTION
fixes #200 

This may be specific to the Rival 650, or it might be something more general to all SteelSeries mice; I don't have any way to test.  Perhaps it should be part of the device profile?  All I can say is that without this patch, `rivalcfg` interacting with my mouse is the luck of the draw; with it, I can reliably get the battery percentage.

I can say that at least it works with both wired & wireless devices.