### PR TITLE
Improve profile generation.

### DIFF
--- a/rivalcfg/devices/__init__.py
+++ b/rivalcfg/devices/__init__.py
@@ -259,6 +259,8 @@ def _generate_profiles():
             profile = item.profile.copy()
             profile_name = (model["vendor_id"], model["product_id"])
             del profile["models"]
+            for k, v in model.items():
+                profile[k] = v
             #   if k == "override_defaults":
             #            continue
             #        profile[k] = v
@@ -266,6 +268,7 @@ def _generate_profiles():
             #  TO-DO override defaults
             profiles[profile_name] = profile
     return profiles
+
 
 
 PROFILES = _generate_profiles()

--- a/rivalcfg/devices/__init__.py
+++ b/rivalcfg/devices/__init__.py
@@ -268,5 +268,4 @@ def _generate_profiles():
     return profiles
 
 
-
 PROFILES = _generate_profiles()

--- a/rivalcfg/devices/__init__.py
+++ b/rivalcfg/devices/__init__.py
@@ -260,11 +260,6 @@ def _generate_profiles():
             del profile["models"]
             for k, v in model.items():
                 profile[k] = v
-            #   if k == "override_defaults":
-            #            continue
-            #        profile[k] = v
-
-            #  TO-DO override defaults
             profiles[profile_name] = profile
     return profiles
 

--- a/rivalcfg/devices/__init__.py
+++ b/rivalcfg/devices/__init__.py
@@ -222,34 +222,34 @@ def _generate_profiles():
     :rtype: dict
     """
     from . import (  # noqa: F401
-        aerox3,  # noqa: F401
-        aerox3_wireless_wired,  # noqa: F401
-        aerox3_wireless_wireless,  # noqa: F401
-        aerox5_wireless_wired,  # noqa: F401
-        aerox5_wireless_wireless,  # noqa: F401
-        aerox9_wireless_wired,  # noqa: F401
-        aerox9_wireless_wireless,  # noqa: F401
-        kanav2,  # noqa: F401
-        kinzuv2,  # noqa: F401
-        prime,  # noqa: F401
-        prime_wireless_wired,  # noqa: F401
-        prime_wireless_wireless,  # noqa: F401
-        rival3,  # noqa: F401
-        rival3_wireless,  # noqa: F401
-        rival95,  # noqa: F401
-        rival100,  # noqa: F401
-        rival110,  # noqa: F401
-        rival300,  # noqa: F401
-        rival300s,  # noqa: F401
-        rival310,  # noqa: F401
-        rival500,  # noqa: F401
-        rival600,  # noqa: F401
-        rival650,  # noqa: F401
-        rival700,  # noqa: F401
-        sensei310,  # noqa: F401
-        sensei_raw,  # noqa: F401
-        sensei_ten,  # noqa: F401
-    )  # noqa: F401
+        aerox3,
+        aerox3_wireless_wired,
+        aerox3_wireless_wireless,
+        aerox5_wireless_wired,
+        aerox5_wireless_wireless,
+        aerox9_wireless_wired,
+        aerox9_wireless_wireless,
+        kanav2,
+        kinzuv2,
+        prime,
+        prime_wireless_wired,
+        prime_wireless_wireless,
+        rival3,
+        rival3_wireless,
+        rival95,
+        rival100,
+        rival110,
+        rival300,
+        rival300s,
+        rival310,
+        rival500,
+        rival600,
+        rival650,
+        rival700,
+        sensei310,
+        sensei_raw,
+        sensei_ten,
+    )
 
     profile_modules = locals()
     profiles = {}

--- a/rivalcfg/devices/__init__.py
+++ b/rivalcfg/devices/__init__.py
@@ -149,6 +149,7 @@ Module API
 import os
 import types
 
+from .. import usbhid
 
 PROFILES = None
 
@@ -265,6 +266,7 @@ def _generate_profiles():
             #  TO-DO override defaults
             profiles[profile_name] = profile
     return profiles
+
 
 
 PROFILES = _generate_profiles()

--- a/rivalcfg/devices/__init__.py
+++ b/rivalcfg/devices/__init__.py
@@ -147,7 +147,6 @@ Module API
 
 
 import os
-import types
 
 from .. import usbhid
 
@@ -222,7 +221,7 @@ def _generate_profiles():
 
     :rtype: dict
     """
-    from . import (
+    from . import (  # noqa: F401
         aerox3,  # noqa: F401
         aerox3_wireless_wired,  # noqa: F401
         aerox3_wireless_wireless,  # noqa: F401
@@ -250,7 +249,7 @@ def _generate_profiles():
         sensei310,  # noqa: F401
         sensei_raw,  # noqa: F401
         sensei_ten,  # noqa: F401
-    )
+    )  # noqa: F401
 
     profile_modules = locals()
     profiles = {}
@@ -268,7 +267,6 @@ def _generate_profiles():
             #  TO-DO override defaults
             profiles[profile_name] = profile
     return profiles
-
 
 
 PROFILES = _generate_profiles()

--- a/rivalcfg/devices/__init__.py
+++ b/rivalcfg/devices/__init__.py
@@ -149,35 +149,6 @@ Module API
 import os
 import types
 
-from . import aerox3  # noqa: F401
-from . import aerox3_wireless_wired  # noqa: F401
-from . import aerox3_wireless_wireless  # noqa: F401
-from . import aerox5_wireless_wired  # noqa: F401
-from . import aerox5_wireless_wireless  # noqa: F401
-from . import aerox9_wireless_wired  # noqa: F401
-from . import aerox9_wireless_wireless  # noqa: F401
-from . import kanav2  # noqa: F401
-from . import kinzuv2  # noqa: F401
-from . import prime  # noqa: F401
-from . import prime_wireless_wired  # noqa: F401
-from . import prime_wireless_wireless  # noqa: F401
-from . import rival3  # noqa: F401
-from . import rival3_wireless  # noqa: F401
-from . import rival95  # noqa: F401
-from . import rival100  # noqa: F401
-from . import rival110  # noqa: F401
-from . import rival300  # noqa: F401
-from . import rival300s  # noqa: F401
-from . import rival310  # noqa: F401
-from . import rival500  # noqa: F401
-from . import rival600  # noqa: F401
-from . import rival650  # noqa: F401
-from . import rival700  # noqa: F401
-from . import sensei310  # noqa: F401
-from . import sensei_raw  # noqa: F401
-from . import sensei_ten  # noqa: F401
-from .. import usbhid
-
 
 PROFILES = None
 
@@ -250,21 +221,48 @@ def _generate_profiles():
 
     :rtype: dict
     """
+    from . import (
+        aerox3,  # noqa: F401
+        aerox3_wireless_wired,  # noqa: F401
+        aerox3_wireless_wireless,  # noqa: F401
+        aerox5_wireless_wired,  # noqa: F401
+        aerox5_wireless_wireless,  # noqa: F401
+        aerox9_wireless_wired,  # noqa: F401
+        aerox9_wireless_wireless,  # noqa: F401
+        kanav2,  # noqa: F401
+        kinzuv2,  # noqa: F401
+        prime,  # noqa: F401
+        prime_wireless_wired,  # noqa: F401
+        prime_wireless_wireless,  # noqa: F401
+        rival3,  # noqa: F401
+        rival3_wireless,  # noqa: F401
+        rival95,  # noqa: F401
+        rival100,  # noqa: F401
+        rival110,  # noqa: F401
+        rival300,  # noqa: F401
+        rival300s,  # noqa: F401
+        rival310,  # noqa: F401
+        rival500,  # noqa: F401
+        rival600,  # noqa: F401
+        rival650,  # noqa: F401
+        rival700,  # noqa: F401
+        sensei310,  # noqa: F401
+        sensei_raw,  # noqa: F401
+        sensei_ten,  # noqa: F401
+    )
+
+    profile_modules = locals()
     profiles = {}
-    for item in [globals()[name] for name in globals()]:
-        if not isinstance(item, types.ModuleType):
-            continue
-        if not hasattr(item, "profile"):
-            continue
+    for item in profile_modules.values():
         for model in item.profile["models"]:
             profile = item.profile.copy()
             profile_name = (model["vendor_id"], model["product_id"])
             del profile["models"]
-            for k, v in model.items():
-                if k == "override_defaults":
-                    continue
-                profile[k] = v
-            # TODO override_defaults
+            #   if k == "override_defaults":
+            #            continue
+            #        profile[k] = v
+
+            #  TO-DO override defaults
             profiles[profile_name] = profile
     return profiles
 


### PR DESCRIPTION
Benefits: Instead of using globals() and filtering the results, this imports the profiles in function and then uses locals(). This adds four benefits.
 - 1: This can allow refreshing profiles in case of profile only updates or any other situation without restarting the application. This aspect is mainly beneficial for a GUI implementation.
 - 2: This removes the need to use types.ModuleType just for a single conditional. While it isn't the main point, it resulted in roughly a 0.1-0.2 Mb decrease in RAM usage.
 - 3: Removing the conditionals resulted in a roughly 5-10% performance improvement for the function.
 - 4: In the rare case a global value has a property, method or attribute named "profile", the old version would give an error, this way it won't get the value at all let alone give an error. 

Tests were measured using timeit comparing the old and new solutions running with numbers set to 1000000. So results are based on 1000000 times of the function being run.

Unit: seconds
Python version: 3.11.3
Old results:
*	70.173
*	71.835
*	70.173

New results:
*	64.133
*	64.187
*	64.165

*Edit: Performance numbers, after a reboot, they became much closer. Newer version is still faster even with the imports.
