### PR TITLE
Solves battery level shows 630% when mouse is off #187

### DIFF
--- a/rivalcfg/__main__.py
+++ b/rivalcfg/__main__.py
@@ -51,7 +51,7 @@ def _render_battery_level(level=None, is_charging=None):
         result.append("[%-10s] %i %%" % ("=" * int(level / 10), level))
 
     if is_charging is None and level is None:
-        result.append("Unable to get the battery level")
+        result.append("Unable to get the battery level. Is the mouse turned on?")
 
     return " ".join(result)
 

--- a/rivalcfg/mouse.py
+++ b/rivalcfg/mouse.py
@@ -133,7 +133,7 @@ class Mouse:
 
         .. NOTE::
 
-           A value of ``None`` means the featue is not supported.
+           A value of ``None`` means the feature is not supported or that the mouse is turned off.
         """
         result = {
             "is_charging": None,
@@ -150,6 +150,9 @@ class Mouse:
             self.mouse_profile["battery_level"]["response_length"],
             timeout_ms=200,
         )
+        
+        if data[1] == 0xff:
+            return result
 
         try:
             if "is_charging" in self.mouse_profile["battery_level"]:

--- a/rivalcfg/mouse.py
+++ b/rivalcfg/mouse.py
@@ -151,9 +151,6 @@ class Mouse:
             timeout_ms=200,
         )
 
-        if data[1] == 0xFF:
-            return result
-
         try:
             if "is_charging" in self.mouse_profile["battery_level"]:
                 result["is_charging"] = self.mouse_profile["battery_level"][
@@ -167,6 +164,9 @@ class Mouse:
                 result["level"] = self.mouse_profile["battery_level"]["level"](data)
         except Exception:
             pass
+
+        if result["level"] > 100 or result["level"] < 0:
+            return {"is_charging": None, "level": None}
 
         return result
 

--- a/rivalcfg/mouse.py
+++ b/rivalcfg/mouse.py
@@ -150,8 +150,8 @@ class Mouse:
             self.mouse_profile["battery_level"]["response_length"],
             timeout_ms=200,
         )
-        
-        if data[1] == 0xff:
+
+        if data[1] == 0xFF:
             return result
 
         try:


### PR DESCRIPTION
I have verified that the bug also occurs with an Aerox 5 Wireless. When the device is switched off, the value of `data[1]` becomes `0xFF`. To address this, I modified the battery function to return None if the battery level is outside the range of 0 to 100. Additionally, I updated the error message and the documentation comment. I also fixed a typo in the original comment.