### PR TITLE
Unrecognized arguments error when no device is found. #213

### DIFF
--- a/rivalcfg/__main__.py
+++ b/rivalcfg/__main__.py
@@ -76,6 +76,9 @@ def main(args=sys.argv[1:]):
     ):
         try:
             mouse = get_first_mouse()
+            if not mouse:
+                print("E: No supported device found.")
+                sys.exit(1)
         except IOError as error:
             if "--help" not in sys.argv and "-h" not in sys.argv:
                 raise error

--- a/rivalcfg/__main__.py
+++ b/rivalcfg/__main__.py
@@ -58,7 +58,7 @@ def _render_battery_level(level=None, is_charging=None):
 
 def main(args=sys.argv[1:]):
     # Display a message when no argument given
-    if len(sys.argv) == 1:
+    if not args:
         print("USAGE:\n  rivalcfg --help")
         sys.exit(1)
 
@@ -68,19 +68,19 @@ def main(args=sys.argv[1:]):
     # Try to open a mouse
     mouse = None
     if (
-        "--print-debug" not in sys.argv
-        and "--list" not in sys.argv
-        and "--version" not in sys.argv
-        and "--update-udev" not in sys.argv
-        and "--print-udev" not in sys.argv
+        "--print-debug" not in args
+        and "--list" not in args
+        and "--version" not in args
+        and "--update-udev" not in args
+        and "--print-udev" not in args
     ):
         try:
             mouse = get_first_mouse()
-            if "--help" not in sys.argv and "-h" not in sys.argv and not mouse:
+            if "--help" not in args and "-h" not in args and not mouse:
                 print("E: No supported device found.")
                 sys.exit(1)
         except IOError as error:
-            if "--help" not in sys.argv and "-h" not in sys.argv:
+            if "--help" not in args and "-h" not in args:
                 raise error
 
     cli_parser = argparse.ArgumentParser(prog="rivalcfg", epilog=_EPILOG)

--- a/rivalcfg/__main__.py
+++ b/rivalcfg/__main__.py
@@ -76,7 +76,7 @@ def main(args=sys.argv[1:]):
     ):
         try:
             mouse = get_first_mouse()
-            if not mouse:
+            if "--help" not in sys.argv and "-h" not in sys.argv and not mouse:
                 print("E: No supported device found.")
                 sys.exit(1)
         except IOError as error:

--- a/rivalcfg/cli.py
+++ b/rivalcfg/cli.py
@@ -77,7 +77,7 @@ class PrintUdevRulesAction(argparse.Action):
 
 
 class PrintDebugAction(argparse.Action):
-    """Prints debug informations and exit."""
+    """Prints debug information and exit."""
 
     def __call__(self, parser, namespace, value, option_string=None):
         print(debug.get_debug_info())
@@ -126,7 +126,7 @@ def add_main_cli(cli_parser):
 
     cli_parser.add_argument(
         "--print-debug",
-        help="Prints debug informations and exit",
+        help="Prints debug information and exit",
         nargs=0,
         action=PrintDebugAction,
     )


### PR DESCRIPTION
Solves [#213](https://github.com/flozz/rivalcfg/issues/213) by checking if a supported device is found; if not, "E: No supported device found." is printed and the program exits.

I also fixed two typos in `cli.py`.