### PR TITLE
Add support for the steelseries prime mini without the wireless capable 

### DIFF
--- a/rivalcfg/devices/prime_wireless_wired.py
+++ b/rivalcfg/devices/prime_wireless_wired.py
@@ -19,6 +19,12 @@ profile = {
             "product_id": 0x184A,
             "endpoint": 3,
         },
+        {
+            "name": "SteelSeries Prime Mini (not wireless),
+            "vendor_id": 0x1038,
+            "product_id": 0x184D,
+            "endpoint": 3,
+        },
     ],
     "settings": {
         "sensitivity": {

--- a/rivalcfg/devices/prime_wireless_wired.py
+++ b/rivalcfg/devices/prime_wireless_wired.py
@@ -20,7 +20,7 @@ profile = {
             "endpoint": 3,
         },
         {
-            "name": "SteelSeries Prime Mini (not wireless),
+            "name": "SteelSeries Prime Mini (not wireless)",
             "vendor_id": 0x1038,
             "product_id": 0x184D,
             "endpoint": 3,


### PR DESCRIPTION
Hello, i want to introduce the add for the original steelseries prime mini without the capable to be wirless or wired because it stay always in wired mode :) 

Idk how to call as name but i tested and is working fine

Best Regards,
NextWorks