### PR TITLE
Add Prime+ support

### DIFF
--- a/rivalcfg/devices/prime.py
+++ b/rivalcfg/devices/prime.py
@@ -21,6 +21,12 @@ profile = {
             "product_id": 0x1856,
             "endpoint": 0,
         },
+        {
+            "name": "SteelSeries Prime+",
+            "vendor_id": 0x1038,
+            "product_id": 0x182C,
+            "endpoint": 0,
+        },
     ],
     "settings": {
         "sensitivity": {


### PR DESCRIPTION
Closes #201
Adds the SteelSeries Prime+ as a model variant in the existing Prime profile. The Prime+ uses the same USB HID protocol and command set as the Prime, confirmed through testing on my Prime+ and analysis of pcap captures from [OpenRGB#4354](https://gitlab.com/CalcProgrammer1/OpenRGB/-/issues/4354)

To confirm all the options work
Sensitivity
Polling rate
Color
LED Brightness
Buttons Mapping
Reset

The Prime+ has some hardware differences from the Prime (OLED screen, lift-off distance sensor, slightly heavier) but these are unlikely to affect the USB HID protocol used by rivalcfg, except perhaps OLED screen. Perhaps this could be captured as it can be changed from GG. So let me know if you're happy for this to be part of prime.py or if you want a prime_plus.py file.

The pcap captures also show support for color-shift (mode `0x04`) and multi-color breathe (mode `0x03`) LED effects. But these might require a new handler? These additional effects would likely be identical to the Prime.